### PR TITLE
chore: update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -29,7 +29,7 @@ jobs:
     needs: test_programs
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -46,7 +46,7 @@ jobs:
     needs: test_programs
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -69,7 +69,7 @@ jobs:
     needs: generate_idls
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -98,7 +98,7 @@ jobs:
     needs: generate_idls
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -119,7 +119,7 @@ jobs:
     needs: generate_clients
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -136,7 +136,7 @@ jobs:
     needs: generate_clients
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -153,7 +153,7 @@ jobs:
 #    needs: generate_clients
 #    steps:
 #      - name: Git Checkout
-#        uses: actions/checkout@v4
+#        uses: actions/checkout@v5
 #
 #      - name: Setup Environment
 #        uses: ./.github/actions/setup
@@ -175,7 +175,7 @@ jobs:
 #    needs: generate_clients
 #    steps:
 #      - name: Git Checkout
-#        uses: actions/checkout@v4
+#        uses: actions/checkout@v5
 #
 #      - name: Setup Environment
 #        uses: ./.github/actions/setup


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0