### PR TITLE
fix: avoid error when PRODUCT_NAME is empty

### DIFF
--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -5,8 +5,7 @@ DEVICE=tmp/keys/device1.json
 USER=tmp/keys/user1.json
 
 PRODUCT_NAME=$1
-if [ -e $PRODUCT_NAME ]
-then
+if [ -z "$PRODUCT_NAME" ]; then
     PRODUCT_NAME='Product 1'
 fi
 


### PR DESCRIPTION
`[ -e ]` was failing when `$1` wasn’t passed.
now we check the variable first, so no more errors if it’s empty.
